### PR TITLE
Feature/poll controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "passport-http-bearer": "^1.0.1",
     "pg": "^7.4.1",
     "pg-hstore": "^2.3.2",
-    "sequelize": "^4.32.6"
+    "sequelize": "^4.32.6",
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/controllers/Polls.js
+++ b/src/controllers/Polls.js
@@ -28,7 +28,7 @@ export default {
       res,
       jsonData: true,
       query: {
-        userId: req.params.userId,
+        userId: req.user.dataValues.userId,
       },
     });
   },
@@ -44,15 +44,16 @@ export default {
   create(req, res) {
     Polls.create({
       res,
+      userId: req.user.dataValues.userId,
       body: req.body,
     });
   },
   update(req, res) {
     Polls.update({
       res,
+      userId: req.user.dataValues.userId,
       query: {
         id: req.params.pollId,
-        userId: req.params.userId,
       },
       body: req.body,
     });
@@ -60,9 +61,9 @@ export default {
   destroy(req, res) {
     Polls.destroy({
       res,
+      userId: req.user.dataValues.userId,
       query: {
         id: req.params.pollId,
-        userId: req.params.userId,
       },
     });
   },

--- a/src/controllers/Polls.js
+++ b/src/controllers/Polls.js
@@ -1,0 +1,69 @@
+import * as Polls from '../lib/Polls';
+
+export default {
+  list(req, res) {
+    Promise
+      .all([
+        Polls.list({
+          res,
+          query: req.query,
+          returnData: true,
+          jsonData: true,
+        }),
+        Polls.pages({ query: req.query }),
+      ])
+      .then((promises) => {
+        res.status(200).send({
+          rows: promises[0],
+          pages: promises[1],
+        });
+      })
+      .catch((error) => {
+        res.status(400).send(error);
+      });
+  },
+
+  find(req, res) {
+    Polls.find({
+      res,
+      jsonData: true,
+      query: {
+        userId: req.params.userId,
+      },
+    });
+  },
+
+  findOne(req, res) {
+    Polls.findOne({
+      res,
+      where: {
+        id: req.params.pollId,
+      },
+    });
+  },
+  create(req, res) {
+    Polls.create({
+      res,
+      body: req.body,
+    });
+  },
+  update(req, res) {
+    Polls.update({
+      res,
+      query: {
+        id: req.params.pollId,
+        userId: req.params.userId,
+      },
+      body: req.body,
+    });
+  },
+  destroy(req, res) {
+    Polls.destroy({
+      res,
+      query: {
+        id: req.params.pollId,
+        userId: req.params.userId,
+      },
+    });
+  },
+};

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,9 +1,11 @@
 import Sessions from './Sessions';
 import Tests from './Tests';
 import Users from './Users';
+import Polls from './Polls';
 
 export default {
   Sessions,
   Tests,
   Users,
+  Polls,
 };

--- a/src/lib/Polls.js
+++ b/src/lib/Polls.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies,
- no-console, max-len */
+ no-console, consistent-return */
 
 import DB from '../models';
 import { pageCount } from '../helpers/Data';
@@ -138,13 +138,18 @@ export function create(options) {
           status: 'active',
           createdAt: new Date(),
           updatedAt: new Date(),
+        }).then((Poll) => {
+          const data = jsonPoll(Poll);
+          return res.status(200).send({
+            message: 'New Poll has been Activated!',
+            data,
+          });
         })
         .catch((error) => {
           console.log(error);
 
           return res.status(400).send(error);
         });
-      return res.status(200).send({ message: 'New Poll has been Activated!' });
     });
 }
 
@@ -192,7 +197,6 @@ export function destroy(options) {
     returnData: true,
   })
     .then((Poll) => {
-      console.log(Poll);
       if (Poll.json.userId !== userId) { return res.status(401).send({ message: 'You can\'t delete Polls that are not yours' }); }
       if (Poll.json.status === 'active') { return res.status(403).send({ message: 'You can\'t delete a active pole, please close it first' }); }
       DB.Poll

--- a/src/lib/Polls.js
+++ b/src/lib/Polls.js
@@ -1,0 +1,214 @@
+/* eslint-disable import/no-extraneous-dependencies,
+ no-console, max-len */
+
+import DB from '../models';
+import { pageCount } from '../helpers/Data';
+import uuidv4 from 'uuid/v4';
+
+function jsonPoll(Poll) {
+  return {
+    id: Poll.id,
+    userId: Poll.userId,
+    questionnaireId: Poll.questionnaireId,
+    link: Poll.link,
+    qrCode: Poll.qrCode,
+    status: Poll.status,
+    maxNumOfVotes: Poll.maxNumOfVotes,
+    duration: Poll.duration,
+    createdAt: Poll.createdAt,
+    updatedAt: Poll.updatedAt,
+    closedAt: Poll.closedAt,
+
+  };
+}
+
+function jsonPolls(Polls) {
+  return Polls
+    .map(Poll => jsonPoll(Poll));
+}
+
+export function list(options) {
+  const {
+    res, returnData, jsonData,
+  } = options;
+
+  return DB.Poll
+    .findAll({})
+    .then((Polls) => {
+      const data = jsonData ? jsonPolls(Polls) : Polls;
+
+      if (returnData) return data;
+
+      return res.status(data ? 200 : 404).send(data);
+    })
+    .catch((error) => {
+      console.log(error);
+
+      return returnData ? error : res.status(400).send(error);
+    });
+}
+
+export function pages({ query }) {
+  return DB.Poll
+    .count({
+      col: 'id',
+    })
+    .then(count => pageCount(query, count));
+}
+
+export function find(options) {
+  const {
+    res, query, returnData, jsonData,
+  } = options;
+  return DB.Poll
+    .findAll({ where: query })
+    .then((Polls) => {
+      const data = jsonData ? jsonPolls(Polls) : Polls;
+
+      if (returnData) return data;
+
+      return res.status(data ? 200 : 404).send(data);
+    })
+    .catch((error) => {
+      console.log(error);
+
+      return returnData ? error : res.status(400).send(error);
+    });
+}
+
+export function findOne(options) {
+  const { res, where, returnData } = options;
+
+  return DB.Poll
+    .findOne({
+      where,
+    })
+    .then((Poll) => {
+      const json = Poll ? jsonPoll(Poll) : null;
+
+      if (returnData) return { object: Poll, json };
+
+      return res.status(Poll ? 200 : 404).send(json);
+    })
+    .catch((error) => {
+      console.log(error);
+
+      return returnData ? error : res.status(400).send(error);
+    });
+}
+
+export function create(options) {
+  const { res, body } = options;
+  const {
+    userId, questionnaireId,
+  } = body;
+
+  DB.Questionnaire
+    .find({ where: { id: questionnaireId } })
+    .then((Questionnaire) => {
+      let maxNumOfVotes;
+      if (Questionnaire.dataValues.type === 'basic') {
+        maxNumOfVotes = 50;
+      } else if (Questionnaire.dataValues.type === 'onetime-premium') {
+        console.log('test');
+        DB.Questionnaire
+          .update({
+            type: 'basic',
+            updatedAt: new Date(),
+          }, {
+            where: { id: questionnaireId },
+          })
+          .catch((error) => {
+            console.log(error);
+
+            return res.status(400).send(error);
+          });
+      }
+
+      const generatedId = uuidv4();
+
+      DB.Poll
+        .create({
+          id: generatedId,
+          userId,
+          questionnaireId,
+          maxNumOfVotes,
+          link: `${process.env.ALLOW_ORIGIN}/polls/${generatedId}`,
+          status: 'active',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .catch((error) => {
+          console.log(error);
+
+          return res.status(400).send(error);
+        });
+      return res.status(200).send({ message: 'New Poll has been Activated!' });
+    });
+}
+
+export function update(options) {
+  const {
+    res, query,
+  } = options;
+
+  findOne({
+    res,
+    where: query,
+    returnData: true,
+  })
+    .then((Poll) => {
+      if (Poll.json.status !== 'active') { return res.status(403).send({ message: 'This poll is already closed' }); }
+
+      DB.Poll
+        .update({
+          status: 'closed',
+          updatedAt: new Date(),
+          closedAt: new Date(),
+        }, {
+          where: query,
+        })
+        .catch((error) => {
+          console.log(error);
+
+          return res.status(400).send(error);
+        });
+      return res.status(200).send({ message: 'Your poll is now closed!' });
+    })
+    .catch((error) => {
+      console.log(error);
+
+      return res.status(400).send(error);
+    });
+}
+
+export function destroy(options) {
+  const { res, query } = options;
+  findOne({
+    res,
+    where: query,
+    returnData: true,
+  })
+    .then((Poll) => {
+      console.log(Poll);
+      if (Poll.json.status === 'active') { return res.status(403).send({ message: 'you cant delete a active pole, please close it first' }); }
+      DB.Poll
+        .destroy({ where: query })
+        .then(() => res.status(200).send())
+        .catch((error) => {
+          console.log(error);
+
+          return res.status(400).send(error);
+        });
+      return res.status(200).send({ message: 'Poll deleted allong with all data' });
+    })
+    .catch((error) => {
+      console.log(error);
+
+      return res.status(400).send(error);
+    });
+}
+
+/* eslint-enable import/no-extraneous-dependencies, no-use-before-define,
+  prefer-destructuring, radix, no-unused-vars, consistent-return, no-shadow, no-console */
+

--- a/src/migrations/20180418225900-create-poll.js
+++ b/src/migrations/20180418225900-create-poll.js
@@ -6,9 +6,8 @@ module.exports = {
   up: (queryInterface, Sequelize) => queryInterface.createTable('Polls', {
     id: {
       allowNull: false,
-      autoIncrement: true,
       primaryKey: true,
-      type: Sequelize.INTEGER,
+      type: Sequelize.STRING,
     },
     userId: {
       type: Sequelize.INTEGER,
@@ -44,7 +43,6 @@ module.exports = {
     },
     duration: {
       type: Sequelize.INTEGER,
-      required: true,
     },
     createdAt: {
       allowNull: false,

--- a/src/migrations/20180418232700-create-answer.js
+++ b/src/migrations/20180418232700-create-answer.js
@@ -11,7 +11,7 @@ module.exports = {
       type: Sequelize.INTEGER,
     },
     pollId: {
-      type: Sequelize.INTEGER,
+      type: Sequelize.STRING,
       references: {
         model: 'Polls',
         key: 'id',

--- a/src/models/Poll.js
+++ b/src/models/Poll.js
@@ -1,9 +1,8 @@
 export default (sequelize, DataTypes) => {
   const Poll = sequelize.define('Poll', {
     id: {
-      type: DataTypes.INTEGER,
+      type: DataTypes.STRING,
       primaryKey: true,
-      autoIncrement: true,
     },
     link: {
       type: DataTypes.STRING,

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -26,4 +26,11 @@ export default (app) => {
   app.patch('/tests/:id', C.Tests.update);
   app.put('/tests/:id', C.Tests.update);
   app.delete('/tests/:id', C.Tests.destroy);
+
+  app.get('/polls', C.Polls.list);
+  app.get('/users/:userId/polls', C.Polls.find);
+  app.put('/users/:userId/polls/:pollId', C.Polls.update);
+  app.delete('/users/:userId/polls/:pollId', C.Polls.destroy);
+  app.get('/polls/:pollId', C.Polls.findOne);
+  app.post('/polls', C.Polls.create);
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -27,7 +27,7 @@ export default (app) => {
   app.put('/tests/:id', C.Tests.update);
   app.delete('/tests/:id', C.Tests.destroy);
 
-  app.get('/polls', C.Polls.list);
+  app.get('/polls', authBearer(), C.Polls.list);
   app.get('/users/:userId/polls', authBearer(), C.Polls.find);
   app.put('/users/:userId/polls/:pollId', authBearer(), C.Polls.update);
   app.delete('/users/:userId/polls/:pollId', authBearer(), C.Polls.destroy);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -28,9 +28,9 @@ export default (app) => {
   app.delete('/tests/:id', C.Tests.destroy);
 
   app.get('/polls', C.Polls.list);
-  app.get('/users/:userId/polls', C.Polls.find);
-  app.put('/users/:userId/polls/:pollId', C.Polls.update);
-  app.delete('/users/:userId/polls/:pollId', C.Polls.destroy);
+  app.get('/users/:userId/polls', authBearer(), C.Polls.find);
+  app.put('/users/:userId/polls/:pollId', authBearer(), C.Polls.update);
+  app.delete('/users/:userId/polls/:pollId', authBearer(), C.Polls.destroy);
   app.get('/polls/:pollId', C.Polls.findOne);
-  app.post('/polls', C.Polls.create);
+  app.post('/polls', authBearer(), C.Polls.create);
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -28,9 +28,9 @@ export default (app) => {
   app.delete('/tests/:id', C.Tests.destroy);
 
   app.get('/polls', authBearer(), C.Polls.list);
-  app.get('/users/:userId/polls', authBearer(), C.Polls.find);
-  app.put('/users/:userId/polls/:pollId', authBearer(), C.Polls.update);
-  app.delete('/users/:userId/polls/:pollId', authBearer(), C.Polls.destroy);
+  app.get('/my-polls', authBearer(), C.Polls.find);
+  app.post('/my-polls', authBearer(), C.Polls.create);
+  app.put('/my-polls/:pollId', authBearer(), C.Polls.update);
+  app.delete('/my-polls/:pollId', authBearer(), C.Polls.destroy);
   app.get('/polls/:pollId', C.Polls.findOne);
-  app.post('/polls', authBearer(), C.Polls.create);
 };

--- a/src/seeders/20180419111400-polls.js
+++ b/src/seeders/20180419111400-polls.js
@@ -1,14 +1,15 @@
 /* eslint-disable no-unused-vars, no-sequences, no-unused-expressions,
-no-use-before-define, no-param-reassign, no-console, func-names */
+no-use-before-define, no-param-reassign, no-console, func-names, import/first */
+
 
 module.exports = {
   up: (queryInterface, Sequelize) => queryInterface.bulkInsert('Polls', [
-    poll(1, 1, 'https://localhost:7771/polls/1', 'https://localhost:7771/polls/1', 'closed', 10, mockDateTime(20)),
-    poll(1, 1, 'https://localhost:7771/polls/2', 'https://localhost:7771/polls/2', 'closed', 60, mockDateTime(20)),
-    poll(2, 3, 'https://localhost:7771/polls/3', 'https://localhost:7771/polls/3', 'closed', 120, mockDateTime(20)),
-    poll(1, 2, 'https://localhost:7771/polls/4', 'https://localhost:7771/polls/4', 'closed', 5, mockDateTime(20)),
-    poll(3, 4, 'https://localhost:7771/polls/5', 'https://localhost:7771/polls/5', 'closed', 15, mockDateTime(20)),
-    poll(4, 5, 'https://localhost:7771/polls/6', 'https://localhost:7771/polls/6', 'closed', 240, mockDateTime(20)),
+    poll('1', 1, 1, 'http://localhost:7771/polls/1', 'http://localhost:7771/polls/1', 'closed', 10, mockDateTime(20)),
+    poll('2', 1, 1, 'http://localhost:7771/polls/2', 'http://localhost:7771/polls/2', 'closed', 60, mockDateTime(20)),
+    poll('3', 2, 3, 'http://localhost:7771/polls/3', 'http://localhost:7771/polls/3', 'closed', 120, mockDateTime(20)),
+    poll('4', 1, 2, 'http://localhost:7771/polls/4', 'http://localhost:7771/polls/4', 'closed', 5, mockDateTime(20)),
+    poll('5', 3, 4, 'http://localhost:7771/polls/5', 'http://localhost:7771/polls/5', 'closed', 15, mockDateTime(20)),
+    poll('6', 4, 5, 'http://localhost:7771/polls/6', 'http://localhost:7771/polls/6', 'closed', 240, mockDateTime(20)),
   ], {}),
 
   down: (queryInterface, Sequelize) => queryInterface.bulkDelete('Polls', null, {}),
@@ -16,18 +17,18 @@ module.exports = {
 
 const Moment = require('moment');
 
-function poll(userId, questionnaireId, link, qrCode, status, duration, date) {
+function poll(id, userId, questionnaireId, link, qrCode, status, duration, date) {
   const newDate = new Date();
   const closedDate = new Date(date);
-  let maxVotes;
 
   const data = {
+    id,
     userId,
     questionnaireId,
     link,
     qrCode,
     status,
-    maxNumOfVotes: maxVotes,
+    maxNumOfVotes: null,
     duration,
     createdAt: newDate,
     updatedAt: newDate,
@@ -53,3 +54,4 @@ function rand(min = 0, max = 60) {
 
   return Math.floor(Math.random() * (max - min)) + min;
 }
+

--- a/src/server.js
+++ b/src/server.js
@@ -35,6 +35,10 @@ app.use(cors({
   methods: 'GET, POST, PATCH, PUT, DELETE, OPTIONS',
 }));
 
+app.use(bodyParser.urlencoded({
+  extended: true,
+}));
+
 app.use(bodyParser.json());
 
 routes(app);


### PR DESCRIPTION
GET-request to `/polls` - require auth (gets all polls)
GET-request to `/users/:userId/polls`  - require auth (gets all polls of the authenticated user)
POST-request to `/polls`  - require auth and json object with a questionnairId to be sent with te request body (creates a new poll)
PUT-request to` /users/:userId/polls/:pollId ` - require auth (closes the selected poll)
DELETE-request to `/users/:userId/polls/:pollId`  - require auth (deletes the selected poll and all associated answers and votes)
GET -request to `/polls/:pollId` (gets a spesific poll) - does not require auth

To test the routes that require auth you must first login to the application, I have been having truble doing this via post man (from what I can tell the login in that Axel has set up uses JWT to encrypt the email and password used to sign up and I have not been able to replicate this with postman so the simplest way to test those routs is to simply login to the application via the login form and then get the token from the local-storage and past it in to postman (as a Bearer Token) and then test the routes.

also remember to reset the database first with bin/pg/restetdb

Btw sorry for the messy naming scem on the routes please let me know if you have any sugestions on a better way of naming them (thinking about skipping userId on all the routes sins it seams a bit redundant)