### PR TITLE
Feature/multiselect questions

### DIFF
--- a/src/lib/Questions.js
+++ b/src/lib/Questions.js
@@ -93,7 +93,7 @@ export function update(data) {
     res, userId, body, questionId,
   } = data;
 
-  const { name, options } = body;
+  const { name, type, options } = body;
 
   find({
     res,
@@ -116,6 +116,7 @@ export function update(data) {
 
         DB.Question.update({
           name,
+          type,
           updatedAt: new Date(),
         }, {
           where: { id: questionId },

--- a/src/lib/Vote.js
+++ b/src/lib/Vote.js
@@ -40,7 +40,7 @@ export function list(options) {
 export function create(options) {
   const { res, body } = options;
   const {
-    optionId, questionId, pollId, answerId
+    optionIds, questionId, pollId, answerId
   } = body;
 
   DB.Vote
@@ -49,11 +49,17 @@ export function create(options) {
     pollId,
     answerId,
   }).then((Vote) => {
-
-      DB.OptionVote.create({  
+    const newOptions = optionIds.map(optionId => {
+      const newOption = {
         optionId,
         voteId: Vote.id,
-      }).then((OptionVote) => {
+      }
+
+      return newOption;
+    })
+      DB.OptionVote
+      .bulkCreate(newOptions)
+      .then((OptionVote) => {
         Vote.options = OptionVote;
         const data = jsonVote(Vote);
         return res.status(200).send({
@@ -68,6 +74,3 @@ export function create(options) {
   });
 
 }
-
-// create function
-// från vote, skapa en plats i ledger table mellan Options och Vote

--- a/src/migrations/20180418231700-create-question.js
+++ b/src/migrations/20180418231700-create-question.js
@@ -15,7 +15,7 @@ module.exports = {
       required: true,
     },
     type: {
-      type: Sequelize.ENUM('select-one', 'multiselect', 'short-text'),
+      type: Sequelize.ENUM('select-one', 'multi-select', 'short-text'),
     },
     order: {
       type: Sequelize.INTEGER,

--- a/src/models/Question.js
+++ b/src/models/Question.js
@@ -11,7 +11,7 @@ export default (sequelize, DataTypes) => {
       required: true,
     },
     type: {
-      type: DataTypes.ENUM('select-one', 'multiselect', 'short-text'),
+      type: DataTypes.ENUM('select-one', 'multi-select', 'short-text'),
       required: true,
     },
     order: {


### PR DESCRIPTION
- enable updating question.type
- enable voting for multiple options at the same time
- rename `multiselect` enum to `multi-select`

> note that due to updated in enum name in migrations database needs to be remigrated